### PR TITLE
Ensure that all RCC register accesses call microvisor specific functions

### DIFF
--- a/Drivers/CMSIS/Device/ST/STM32U5xx/Source/Templates/system_stm32u5xx.c
+++ b/Drivers/CMSIS/Device/ST/STM32U5xx/Source/Templates/system_stm32u5xx.c
@@ -101,6 +101,7 @@
   */
 
 #include "stm32u5xx.h"
+#include "mv_bitops.h"
 #include <math.h>
 
 /**
@@ -274,7 +275,7 @@ void SystemCoreClockUpdate(void)
   float_t fracn1, pllvco;
 
   /* Get MSI Range frequency--------------------------------------------------*/
-  if(READ_BIT(RCC->ICSCR1, RCC_ICSCR1_MSIRGSEL) == 0U)
+  if(MV_READ_BIT(RCC->ICSCR1, RCC_ICSCR1_MSIRGSEL) == 0U)
   {
     /* MSISRANGE from RCC_CSR applies */
     msirange = (RCC->CSR & RCC_CSR_MSISSRANGE) >> RCC_CSR_MSISSRANGE_Pos;

--- a/Drivers/CMSIS/Device/ST/STM32U5xx/Source/Templates/system_stm32u5xx_s.c
+++ b/Drivers/CMSIS/Device/ST/STM32U5xx/Source/Templates/system_stm32u5xx_s.c
@@ -111,6 +111,7 @@
 
 #include "stm32u5xx.h"
 #include "partition_stm32u5xx.h"  /* Trustzone-M core secure attributes */
+#include "mv_bitops.h"
 #include <math.h>
 
 /**
@@ -297,7 +298,7 @@ void SystemCoreClockUpdate(void)
   float_t fracn1, pllvco;
 
   /* Get MSI Range frequency--------------------------------------------------*/
-  if(READ_BIT(RCC->ICSCR1, RCC_ICSCR1_MSIRGSEL) == 0U)
+  if(MV_READ_BIT(RCC->ICSCR1, RCC_ICSCR1_MSIRGSEL) == 0U)
   {
     /* MSISRANGE from RCC_CSR applies */
     msirange = (RCC->CSR & RCC_CSR_MSISSRANGE) >> RCC_CSR_MSISSRANGE_Pos;

--- a/Drivers/STM32U5xx_HAL_Driver/Inc/stm32u5xx_hal_rcc.h
+++ b/Drivers/STM32U5xx_HAL_Driver/Inc/stm32u5xx_hal_rcc.h
@@ -2558,7 +2558,7 @@ typedef struct
   *            @arg @ref RCC_MSIRANGE_8  MSI clock is around 3.072 MHz
   * @retval None
   */
-#define __HAL_RCC_MSI_STANDBY_RANGE_CONFIG(__MSIRANGEVALUE__) do {SET_BIT(RCC->ICSCR1, RCC_ICSCR1_MSIRGSEL);\
+#define __HAL_RCC_MSI_STANDBY_RANGE_CONFIG(__MSIRANGEVALUE__) do {MV_SET_BIT(RCC->ICSCR1, RCC_ICSCR1_MSIRGSEL);\
                                                                    MV_MODIFY_REG(RCC->CSR, RCC_CSR_MSISSRANGE,\
                                                                    (__MSIRANGEVALUE__) >> (RCC_ICSCR1_MSISRANGE_Pos -\
                                                                    RCC_CSR_MSISSRANGE_Pos));\
@@ -2575,7 +2575,7 @@ typedef struct
   *            @arg @ref RCC_MSIRANGE_8  MSI clock is around 3.072 MHz
   * @retval None
   */
-#define __HAL_RCC_MSIK_STANDBY_RANGE_CONFIG(__MSIRANGEVALUE__) do {SET_BIT(RCC->ICSCR1, RCC_ICSCR1_MSIRGSEL); \
+#define __HAL_RCC_MSIK_STANDBY_RANGE_CONFIG(__MSIRANGEVALUE__) do {MV_SET_BIT(RCC->ICSCR1, RCC_ICSCR1_MSIRGSEL); \
                                                                     MV_MODIFY_REG(RCC->CSR, RCC_CSR_MSISSRANGE,\
                                                                     (__MSIRANGEVALUE__) >> (RCC_ICSCR1_MSISRANGE_Pos -\
                                                                     RCC_CSR_MSISSRANGE_Pos));\

--- a/Drivers/STM32U5xx_HAL_Driver/Inc/stm32u5xx_ll_bus.h
+++ b/Drivers/STM32U5xx_HAL_Driver/Inc/stm32u5xx_ll_bus.h
@@ -44,6 +44,7 @@ extern "C" {
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32u5xx.h"
+#include "mv_bitops.h"
 
 /** @addtogroup STM32U5xx_LL_Driver
   * @{
@@ -297,9 +298,9 @@ extern "C" {
 __STATIC_INLINE void LL_AHB1_GRP1_EnableClock(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->AHB1ENR, Periphs);
+  MV_SET_BIT(RCC->AHB1ENR, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHB1ENR, Periphs);
+  tmpreg = MV_READ_BIT(RCC->AHB1ENR, Periphs);
   (void)tmpreg;
 }
 
@@ -337,7 +338,7 @@ __STATIC_INLINE void LL_AHB1_GRP1_EnableClock(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_AHB1_GRP1_IsEnabledClock(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->AHB1ENR, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->AHB1ENR, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -374,7 +375,7 @@ __STATIC_INLINE uint32_t LL_AHB1_GRP1_IsEnabledClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB1_GRP1_DisableClock(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->AHB1ENR, Periphs);
+  MV_CLEAR_BIT(RCC->AHB1ENR, Periphs);
 }
 
 /**
@@ -401,7 +402,7 @@ __STATIC_INLINE void LL_AHB1_GRP1_DisableClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB1_GRP1_ForceReset(uint32_t Periphs)
 {
-  SET_BIT(RCC->AHB1RSTR, Periphs);
+  MV_SET_BIT(RCC->AHB1RSTR, Periphs);
 }
 
 /**
@@ -428,7 +429,7 @@ __STATIC_INLINE void LL_AHB1_GRP1_ForceReset(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB1_GRP1_ReleaseReset(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->AHB1RSTR, Periphs);
+  MV_CLEAR_BIT(RCC->AHB1RSTR, Periphs);
 }
 
 /**
@@ -466,9 +467,9 @@ __STATIC_INLINE void LL_AHB1_GRP1_ReleaseReset(uint32_t Periphs)
 __STATIC_INLINE void LL_AHB1_GRP1_EnableClockStopSleep(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->AHB1SMENR, Periphs);
+  MV_SET_BIT(RCC->AHB1SMENR, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHB1SMENR, Periphs);
+  tmpreg = MV_READ_BIT(RCC->AHB1SMENR, Periphs);
   (void)tmpreg;
 }
 
@@ -505,7 +506,7 @@ __STATIC_INLINE void LL_AHB1_GRP1_EnableClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_AHB1_GRP1_IsEnabledClockStopSleep(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->AHB1SMENR, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->AHB1SMENR, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -541,7 +542,7 @@ __STATIC_INLINE uint32_t LL_AHB1_GRP1_IsEnabledClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB1_GRP1_DisableClockStopSleep(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->AHB1SMENR, Periphs);
+  MV_CLEAR_BIT(RCC->AHB1SMENR, Periphs);
 }
 
 /**
@@ -608,9 +609,9 @@ __STATIC_INLINE void LL_AHB1_GRP1_DisableClockStopSleep(uint32_t Periphs)
 __STATIC_INLINE void LL_AHB2_GRP1_EnableClock(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->AHB2ENR1, Periphs);
+  MV_SET_BIT(RCC->AHB2ENR1, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHB2ENR1, Periphs);
+  tmpreg = MV_READ_BIT(RCC->AHB2ENR1, Periphs);
   (void)tmpreg;
 }
 
@@ -668,7 +669,7 @@ __STATIC_INLINE void LL_AHB2_GRP1_EnableClock(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_AHB2_GRP1_IsEnabledClock(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->AHB2ENR1, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->AHB2ENR1, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -723,7 +724,7 @@ __STATIC_INLINE uint32_t LL_AHB2_GRP1_IsEnabledClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB2_GRP1_DisableClock(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->AHB2ENR1, Periphs);
+  MV_CLEAR_BIT(RCC->AHB2ENR1, Periphs);
 }
 
 /**
@@ -776,7 +777,7 @@ __STATIC_INLINE void LL_AHB2_GRP1_DisableClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB2_GRP1_ForceReset(uint32_t Periphs)
 {
-  SET_BIT(RCC->AHB2RSTR1, Periphs);
+  MV_SET_BIT(RCC->AHB2RSTR1, Periphs);
 }
 
 /**
@@ -831,7 +832,7 @@ __STATIC_INLINE void LL_AHB2_GRP1_ForceReset(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB2_GRP1_ReleaseReset(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->AHB2RSTR1, Periphs);
+  MV_CLEAR_BIT(RCC->AHB2RSTR1, Periphs);
 }
 
 /**
@@ -891,9 +892,9 @@ __STATIC_INLINE void LL_AHB2_GRP1_ReleaseReset(uint32_t Periphs)
 __STATIC_INLINE void LL_AHB2_GRP1_EnableClockStopSleep(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->AHB2SMENR1, Periphs);
+  MV_SET_BIT(RCC->AHB2SMENR1, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHB2SMENR1, Periphs);
+  tmpreg = MV_READ_BIT(RCC->AHB2SMENR1, Periphs);
   (void)tmpreg;
 }
 
@@ -953,7 +954,7 @@ __STATIC_INLINE void LL_AHB2_GRP1_EnableClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_AHB2_GRP1_IsEnabledClockStopSleep(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->AHB2SMENR1, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->AHB2SMENR1, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -1012,7 +1013,7 @@ __STATIC_INLINE uint32_t LL_AHB2_GRP1_IsEnabledClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB2_GRP1_DisableClockStopSleep(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->AHB2SMENR1, Periphs);
+  MV_CLEAR_BIT(RCC->AHB2SMENR1, Periphs);
 }
 
 /**
@@ -1045,9 +1046,9 @@ __STATIC_INLINE void LL_AHB2_GRP1_DisableClockStopSleep(uint32_t Periphs)
 __STATIC_INLINE void LL_AHB3_GRP1_EnableClock(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->AHB3ENR, Periphs);
+  MV_SET_BIT(RCC->AHB3ENR, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHB3ENR, Periphs);
+  tmpreg = MV_READ_BIT(RCC->AHB3ENR, Periphs);
   (void)tmpreg;
 }
 
@@ -1073,7 +1074,7 @@ __STATIC_INLINE void LL_AHB3_GRP1_EnableClock(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_AHB3_GRP1_IsEnabledClock(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->AHB3ENR, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->AHB3ENR, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -1098,7 +1099,7 @@ __STATIC_INLINE uint32_t LL_AHB3_GRP1_IsEnabledClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB3_GRP1_DisableClock(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->AHB3ENR, Periphs);
+  MV_CLEAR_BIT(RCC->AHB3ENR, Periphs);
 }
 
 /**
@@ -1123,7 +1124,7 @@ __STATIC_INLINE void LL_AHB3_GRP1_DisableClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB3_GRP1_ForceReset(uint32_t Periphs)
 {
-  SET_BIT(RCC->AHB3RSTR, Periphs);
+  MV_SET_BIT(RCC->AHB3RSTR, Periphs);
 }
 
 /**
@@ -1148,7 +1149,7 @@ __STATIC_INLINE void LL_AHB3_GRP1_ForceReset(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB3_GRP1_ReleaseReset(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->AHB3RSTR, Periphs);
+  MV_CLEAR_BIT(RCC->AHB3RSTR, Periphs);
 }
 
 /**
@@ -1176,9 +1177,9 @@ __STATIC_INLINE void LL_AHB3_GRP1_ReleaseReset(uint32_t Periphs)
 __STATIC_INLINE void LL_AHB3_GRP1_EnableClockStopSleep(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->AHB3SMENR, Periphs);
+  MV_SET_BIT(RCC->AHB3SMENR, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHB3SMENR, Periphs);
+  tmpreg = MV_READ_BIT(RCC->AHB3SMENR, Periphs);
   (void)tmpreg;
 }
 
@@ -1206,7 +1207,7 @@ __STATIC_INLINE void LL_AHB3_GRP1_EnableClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_AHB3_GRP1_IsEnabledClockStopSleep(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->AHB3SMENR, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->AHB3SMENR, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -1233,7 +1234,7 @@ __STATIC_INLINE uint32_t LL_AHB3_GRP1_IsEnabledClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB3_GRP1_DisableClockStopSleep(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->AHB3SMENR, Periphs);
+  MV_CLEAR_BIT(RCC->AHB3SMENR, Periphs);
 }
 
 /**
@@ -1258,9 +1259,9 @@ __STATIC_INLINE void LL_AHB3_GRP1_DisableClockStopSleep(uint32_t Periphs)
 __STATIC_INLINE void LL_AHB2_GRP2_EnableClock(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->AHB2ENR2, Periphs);
+  MV_SET_BIT(RCC->AHB2ENR2, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHB2ENR2, Periphs);
+  tmpreg = MV_READ_BIT(RCC->AHB2ENR2, Periphs);
   (void)tmpreg;
 }
 
@@ -1279,7 +1280,7 @@ __STATIC_INLINE void LL_AHB2_GRP2_EnableClock(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_AHB2_GRP2_IsEnabledClock(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->AHB2ENR2, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->AHB2ENR2, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -1296,7 +1297,7 @@ __STATIC_INLINE uint32_t LL_AHB2_GRP2_IsEnabledClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB2_GRP2_DisableClock(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->AHB2ENR2, Periphs);
+  MV_CLEAR_BIT(RCC->AHB2ENR2, Periphs);
 }
 
 /**
@@ -1313,7 +1314,7 @@ __STATIC_INLINE void LL_AHB2_GRP2_DisableClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB2_GRP2_ForceReset(uint32_t Periphs)
 {
-  SET_BIT(RCC->AHB2RSTR2, Periphs);
+  MV_SET_BIT(RCC->AHB2RSTR2, Periphs);
 }
 
 /**
@@ -1330,7 +1331,7 @@ __STATIC_INLINE void LL_AHB2_GRP2_ForceReset(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB2_GRP2_ReleaseReset(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->AHB2RSTR2, Periphs);
+  MV_CLEAR_BIT(RCC->AHB2RSTR2, Periphs);
 }
 
 /**
@@ -1348,9 +1349,9 @@ __STATIC_INLINE void LL_AHB2_GRP2_ReleaseReset(uint32_t Periphs)
 __STATIC_INLINE void LL_AHB2_GRP2_EnableClockStopSleep(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->AHB2SMENR2, Periphs);
+  MV_SET_BIT(RCC->AHB2SMENR2, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->AHB2SMENR2, Periphs);
+  tmpreg = MV_READ_BIT(RCC->AHB2SMENR2, Periphs);
   (void)tmpreg;
 }
 
@@ -1368,7 +1369,7 @@ __STATIC_INLINE void LL_AHB2_GRP2_EnableClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_AHB2_GRP2_IsEnabledClockStopSleep(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->AHB2SMENR2, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->AHB2SMENR2, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -1385,7 +1386,7 @@ __STATIC_INLINE uint32_t LL_AHB2_GRP2_IsEnabledClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_AHB2_GRP2_DisableClockStopSleep(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->AHB2SMENR2, Periphs);
+  MV_CLEAR_BIT(RCC->AHB2SMENR2, Periphs);
 }
 
 /**
@@ -1435,9 +1436,9 @@ __STATIC_INLINE void LL_AHB2_GRP2_DisableClockStopSleep(uint32_t Periphs)
 __STATIC_INLINE void LL_APB1_GRP1_EnableClock(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->APB1ENR1, Periphs);
+  MV_SET_BIT(RCC->APB1ENR1, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB1ENR1, Periphs);
+  tmpreg = MV_READ_BIT(RCC->APB1ENR1, Periphs);
   (void)tmpreg;
 }
 
@@ -1458,9 +1459,9 @@ __STATIC_INLINE void LL_APB1_GRP1_EnableClock(uint32_t Periphs)
 __STATIC_INLINE void LL_APB1_GRP2_EnableClock(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->APB1ENR2, Periphs);
+  MV_SET_BIT(RCC->APB1ENR2, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB1ENR2, Periphs);
+  tmpreg = MV_READ_BIT(RCC->APB1ENR2, Periphs);
   (void)tmpreg;
 }
 
@@ -1502,7 +1503,7 @@ __STATIC_INLINE void LL_APB1_GRP2_EnableClock(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_APB1_GRP1_IsEnabledClock(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->APB1ENR1, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->APB1ENR1, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -1521,7 +1522,7 @@ __STATIC_INLINE uint32_t LL_APB1_GRP1_IsEnabledClock(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_APB1_GRP2_IsEnabledClock(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->APB1ENR2, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->APB1ENR2, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -1562,7 +1563,7 @@ __STATIC_INLINE uint32_t LL_APB1_GRP2_IsEnabledClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB1_GRP1_DisableClock(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->APB1ENR1, Periphs);
+  MV_CLEAR_BIT(RCC->APB1ENR1, Periphs);
 }
 
 /**
@@ -1581,7 +1582,7 @@ __STATIC_INLINE void LL_APB1_GRP1_DisableClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB1_GRP2_DisableClock(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->APB1ENR2, Periphs);
+  MV_CLEAR_BIT(RCC->APB1ENR2, Periphs);
 }
 
 /**
@@ -1620,7 +1621,7 @@ __STATIC_INLINE void LL_APB1_GRP2_DisableClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB1_GRP1_ForceReset(uint32_t Periphs)
 {
-  SET_BIT(RCC->APB1RSTR1, Periphs);
+  MV_SET_BIT(RCC->APB1RSTR1, Periphs);
 }
 
 /**
@@ -1639,7 +1640,7 @@ __STATIC_INLINE void LL_APB1_GRP1_ForceReset(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB1_GRP2_ForceReset(uint32_t Periphs)
 {
-  SET_BIT(RCC->APB1RSTR2, Periphs);
+  MV_SET_BIT(RCC->APB1RSTR2, Periphs);
 }
 
 /**
@@ -1678,7 +1679,7 @@ __STATIC_INLINE void LL_APB1_GRP2_ForceReset(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB1_GRP1_ReleaseReset(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->APB1RSTR1, Periphs);
+  MV_CLEAR_BIT(RCC->APB1RSTR1, Periphs);
 }
 
 /**
@@ -1697,7 +1698,7 @@ __STATIC_INLINE void LL_APB1_GRP1_ReleaseReset(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB1_GRP2_ReleaseReset(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->APB1RSTR2, Periphs);
+  MV_CLEAR_BIT(RCC->APB1RSTR2, Periphs);
 }
 
 /**
@@ -1737,9 +1738,9 @@ __STATIC_INLINE void LL_APB1_GRP2_ReleaseReset(uint32_t Periphs)
 __STATIC_INLINE void LL_APB1_GRP1_EnableClockStopSleep(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->APB1SMENR1, Periphs);
+  MV_SET_BIT(RCC->APB1SMENR1, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB1SMENR1, Periphs);
+  tmpreg = MV_READ_BIT(RCC->APB1SMENR1, Periphs);
   (void)tmpreg;
 }
 
@@ -1779,7 +1780,7 @@ __STATIC_INLINE void LL_APB1_GRP1_EnableClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_APB1_GRP1_IsEnabledClockStopSleep(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->APB1SMENR1, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->APB1SMENR1, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -1818,7 +1819,7 @@ __STATIC_INLINE uint32_t LL_APB1_GRP1_IsEnabledClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB1_GRP1_DisableClockStopSleep(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->APB1SMENR1, Periphs);
+  MV_CLEAR_BIT(RCC->APB1SMENR1, Periphs);
 }
 
 /**
@@ -1838,9 +1839,9 @@ __STATIC_INLINE void LL_APB1_GRP1_DisableClockStopSleep(uint32_t Periphs)
 __STATIC_INLINE void LL_APB1_GRP2_EnableClockStopSleep(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->APB1SMENR2, Periphs);
+  MV_SET_BIT(RCC->APB1SMENR2, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB1SMENR2, Periphs);
+  tmpreg = MV_READ_BIT(RCC->APB1SMENR2, Periphs);
   (void)tmpreg;
 }
 
@@ -1860,7 +1861,7 @@ __STATIC_INLINE void LL_APB1_GRP2_EnableClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_APB1_GRP2_IsEnabledClockStopSleep(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->APB1SMENR2, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->APB1SMENR2, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -1879,7 +1880,7 @@ __STATIC_INLINE uint32_t LL_APB1_GRP2_IsEnabledClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB1_GRP2_DisableClockStopSleep(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->APB1SMENR2, Periphs);
+  MV_CLEAR_BIT(RCC->APB1SMENR2, Periphs);
 }
 
 /**
@@ -1917,9 +1918,9 @@ __STATIC_INLINE void LL_APB1_GRP2_DisableClockStopSleep(uint32_t Periphs)
 __STATIC_INLINE void LL_APB2_GRP1_EnableClock(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->APB2ENR, Periphs);
+  MV_SET_BIT(RCC->APB2ENR, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB2ENR, Periphs);
+  tmpreg = MV_READ_BIT(RCC->APB2ENR, Periphs);
   (void)tmpreg;
 }
 
@@ -1949,7 +1950,7 @@ __STATIC_INLINE void LL_APB2_GRP1_EnableClock(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_APB2_GRP1_IsEnabledClock(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->APB2ENR, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->APB2ENR, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -1978,7 +1979,7 @@ __STATIC_INLINE uint32_t LL_APB2_GRP1_IsEnabledClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB2_GRP1_DisableClock(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->APB2ENR, Periphs);
+  MV_CLEAR_BIT(RCC->APB2ENR, Periphs);
 }
 
 /**
@@ -2007,7 +2008,7 @@ __STATIC_INLINE void LL_APB2_GRP1_DisableClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB2_GRP1_ForceReset(uint32_t Periphs)
 {
-  SET_BIT(RCC->APB2RSTR, Periphs);
+  MV_SET_BIT(RCC->APB2RSTR, Periphs);
 }
 
 /**
@@ -2036,7 +2037,7 @@ __STATIC_INLINE void LL_APB2_GRP1_ForceReset(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB2_GRP1_ReleaseReset(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->APB2RSTR, Periphs);
+  MV_CLEAR_BIT(RCC->APB2RSTR, Periphs);
 }
 
 /**
@@ -2066,9 +2067,9 @@ __STATIC_INLINE void LL_APB2_GRP1_ReleaseReset(uint32_t Periphs)
 __STATIC_INLINE void LL_APB2_GRP1_EnableClockStopSleep(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->APB2SMENR, Periphs);
+  MV_SET_BIT(RCC->APB2SMENR, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB2SMENR, Periphs);
+  tmpreg = MV_READ_BIT(RCC->APB2SMENR, Periphs);
   (void)tmpreg;
 }
 
@@ -2099,7 +2100,7 @@ __STATIC_INLINE void LL_APB2_GRP1_EnableClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_APB2_GRP1_IsEnabledClockStopSleep(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->APB2SMENR, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->APB2SMENR, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -2128,7 +2129,7 @@ __STATIC_INLINE uint32_t LL_APB2_GRP1_IsEnabledClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB2_GRP1_DisableClockStopSleep(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->APB2SMENR, Periphs);
+  MV_CLEAR_BIT(RCC->APB2SMENR, Periphs);
 }
 
 /**
@@ -2171,9 +2172,9 @@ __STATIC_INLINE void LL_APB2_GRP1_DisableClockStopSleep(uint32_t Periphs)
 __STATIC_INLINE void LL_APB3_GRP1_EnableClock(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->APB3ENR, Periphs);
+  MV_SET_BIT(RCC->APB3ENR, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB3ENR, Periphs);
+  tmpreg = MV_READ_BIT(RCC->APB3ENR, Periphs);
   (void)tmpreg;
 }
 
@@ -2207,7 +2208,7 @@ __STATIC_INLINE void LL_APB3_GRP1_EnableClock(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_APB3_GRP1_IsEnabledClock(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->APB3ENR, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->APB3ENR, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -2240,7 +2241,7 @@ __STATIC_INLINE uint32_t LL_APB3_GRP1_IsEnabledClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB3_GRP1_DisableClock(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->APB3ENR, Periphs);
+  MV_CLEAR_BIT(RCC->APB3ENR, Periphs);
 }
 
 /**
@@ -2273,7 +2274,7 @@ __STATIC_INLINE void LL_APB3_GRP1_DisableClock(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB3_GRP1_ForceReset(uint32_t Periphs)
 {
-  SET_BIT(RCC->APB3RSTR, Periphs);
+  MV_SET_BIT(RCC->APB3RSTR, Periphs);
 }
 
 /**
@@ -2306,7 +2307,7 @@ __STATIC_INLINE void LL_APB3_GRP1_ForceReset(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB3_GRP1_ReleaseReset(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->APB3RSTR, Periphs);
+  MV_CLEAR_BIT(RCC->APB3RSTR, Periphs);
 }
 
 /**
@@ -2340,9 +2341,9 @@ __STATIC_INLINE void LL_APB3_GRP1_ReleaseReset(uint32_t Periphs)
 __STATIC_INLINE void LL_APB3_GRP1_EnableClockStopSleep(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->APB3SMENR, Periphs);
+  MV_SET_BIT(RCC->APB3SMENR, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB3SMENR, Periphs);
+  tmpreg = MV_READ_BIT(RCC->APB3SMENR, Periphs);
   (void)tmpreg;
 }
 
@@ -2377,7 +2378,7 @@ __STATIC_INLINE void LL_APB3_GRP1_EnableClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_APB3_GRP1_IsEnabledClockStopSleep(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->APB3SMENR, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->APB3SMENR, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -2410,7 +2411,7 @@ __STATIC_INLINE uint32_t LL_APB3_GRP1_IsEnabledClockStopSleep(uint32_t Periphs)
   */
 __STATIC_INLINE void LL_APB3_GRP1_DisableClockStopSleep(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->APB3SMENR, Periphs);
+  MV_CLEAR_BIT(RCC->APB3SMENR, Periphs);
 }
 
 /**
@@ -2463,9 +2464,9 @@ __STATIC_INLINE void LL_APB3_GRP1_DisableClockStopSleep(uint32_t Periphs)
 __STATIC_INLINE void LL_SRDAMR_GRP1_EnableAutonomousClock(uint32_t Periphs)
 {
   __IO uint32_t tmpreg;
-  SET_BIT(RCC->SRDAMR, Periphs);
+  MV_SET_BIT(RCC->SRDAMR, Periphs);
   /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->SRDAMR, Periphs);
+  tmpreg = MV_READ_BIT(RCC->SRDAMR, Periphs);
   (void)tmpreg;
 }
 
@@ -2510,7 +2511,7 @@ __STATIC_INLINE void LL_SRDAMR_GRP1_EnableAutonomousClock(uint32_t Periphs)
   */
 __STATIC_INLINE uint32_t LL_SRDAMR_GRP1_IsEnabledAutonomousClock(uint32_t Periphs)
 {
-  return ((READ_BIT(RCC->SRDAMR, Periphs) == Periphs) ? 1UL : 0UL);
+  return ((MV_READ_BIT(RCC->SRDAMR, Periphs) == Periphs) ? 1UL : 0UL);
 }
 
 /**
@@ -2554,7 +2555,7 @@ __STATIC_INLINE uint32_t LL_SRDAMR_GRP1_IsEnabledAutonomousClock(uint32_t Periph
   */
 __STATIC_INLINE void LL_SRDAMR_GRP1_DisableAutonomousClock(uint32_t Periphs)
 {
-  CLEAR_BIT(RCC->SRDAMR, Periphs);
+  MV_CLEAR_BIT(RCC->SRDAMR, Periphs);
 }
 /**
   * @}

--- a/Drivers/STM32U5xx_HAL_Driver/Src/stm32u5xx_hal_cortex.c
+++ b/Drivers/STM32U5xx_HAL_Driver/Src/stm32u5xx_hal_cortex.c
@@ -116,6 +116,7 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32u5xx_hal.h"
+#include "mv_bitops.h"
 
 /** @addtogroup STM32U5xx_HAL_Driver
   * @{
@@ -418,17 +419,17 @@ void HAL_SYSTICK_CLKSourceConfig(uint32_t CLKSource)
     /* Select HCLK_DIV8 as Systick clock source */
     case SYSTICK_CLKSOURCE_HCLK_DIV8:
       CLEAR_BIT(SysTick->CTRL, SysTick_CTRL_CLKSOURCE_Msk);
-      MODIFY_REG(RCC->CCIPR1, RCC_CCIPR1_SYSTICKSEL, (0x00000000U));
+      MV_MODIFY_REG(RCC->CCIPR1, RCC_CCIPR1_SYSTICKSEL, (0x00000000U));
       break;
     /* Select LSI as Systick clock source */
     case SYSTICK_CLKSOURCE_LSI:
       CLEAR_BIT(SysTick->CTRL, SysTick_CTRL_CLKSOURCE_Msk);
-      MODIFY_REG(RCC->CCIPR1, RCC_CCIPR1_SYSTICKSEL, RCC_CCIPR1_SYSTICKSEL_0);
+      MV_MODIFY_REG(RCC->CCIPR1, RCC_CCIPR1_SYSTICKSEL, RCC_CCIPR1_SYSTICKSEL_0);
       break;
     /* Select LSE as Systick clock source */
     case SYSTICK_CLKSOURCE_LSE:
       CLEAR_BIT(SysTick->CTRL, SysTick_CTRL_CLKSOURCE_Msk);
-      MODIFY_REG(RCC->CCIPR1, RCC_CCIPR1_SYSTICKSEL, RCC_CCIPR1_SYSTICKSEL_1);
+      MV_MODIFY_REG(RCC->CCIPR1, RCC_CCIPR1_SYSTICKSEL, RCC_CCIPR1_SYSTICKSEL_1);
       break;
     default:
       /* Nothing to do */

--- a/Drivers/STM32U5xx_HAL_Driver/Src/stm32u5xx_hal_rcc_ex.c
+++ b/Drivers/STM32U5xx_HAL_Driver/Src/stm32u5xx_hal_rcc_ex.c
@@ -24,6 +24,7 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32u5xx_hal.h"
+#include "mv_bitops.h"
 
 /** @addtogroup STM32U5xx_HAL_Driver
   * @{
@@ -705,7 +706,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *pPeriphCl
       pwrclkchanged = SET;
     }
     /* Enable write access to Backup domain */
-    SET_BIT(PWR->DBPR, PWR_DBPR_DBP);
+    MV_SET_BIT(PWR->DBPR, PWR_DBPR_DBP);
 
     /* Wait for Backup domain Write protection disable */
     tickstart = HAL_GetTick();
@@ -722,12 +723,12 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *pPeriphCl
     if (ret == HAL_OK)
     {
       /* Reset the Backup domain only if the RTC Clock source selection is modified from default */
-      tmpregister = READ_BIT(RCC->BDCR, RCC_BDCR_RTCSEL);
+      tmpregister = MV_READ_BIT(RCC->BDCR, RCC_BDCR_RTCSEL);
 
       if ((tmpregister != RCC_RTCCLKSOURCE_NO_CLK) && (tmpregister != pPeriphClkInit->RTCClockSelection))
       {
         /* Store the content of BDCR register before the reset of Backup Domain */
-        tmpregister = READ_BIT(RCC->BDCR, ~(RCC_BDCR_RTCSEL));
+        tmpregister = MV_READ_BIT(RCC->BDCR, ~(RCC_BDCR_RTCSEL));
         /* RTC Clock selection can be changed only if the Backup Domain is reset */
         __HAL_RCC_BACKUPRESET_FORCE();
         __HAL_RCC_BACKUPRESET_RELEASE();
@@ -742,7 +743,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *pPeriphCl
         tickstart = HAL_GetTick();
 
         /* Wait till LSE is ready */
-        while (READ_BIT(RCC->BDCR, RCC_BDCR_LSERDY) == 0U)
+        while (MV_READ_BIT(RCC->BDCR, RCC_BDCR_LSERDY) == 0U)
         {
           if ((HAL_GetTick() - tickstart) > RCC_LSE_TIMEOUT_VALUE)
           {
@@ -2427,7 +2428,7 @@ HAL_StatusTypeDef HAL_RCCEx_EnablePLL2(RCC_PLL2InitTypeDef  *PLL2Init)
   tickstart = HAL_GetTick();
 
   /* Wait till PLL2 is ready to be updated */
-  while (READ_BIT(RCC->CR, RCC_CR_PLL2RDY) != 0U)
+  while (MV_READ_BIT(RCC->CR, RCC_CR_PLL2RDY) != 0U)
   {
     if ((HAL_GetTick() - tickstart) > PLL2_TIMEOUT_VALUE)
     {
@@ -2470,7 +2471,7 @@ HAL_StatusTypeDef HAL_RCCEx_EnablePLL2(RCC_PLL2InitTypeDef  *PLL2Init)
       tickstart = HAL_GetTick();
 
       /* Wait till PLL2 is ready */
-      while (READ_BIT(RCC->CR, RCC_CR_PLL2RDY) == 0U)
+      while (MV_READ_BIT(RCC->CR, RCC_CR_PLL2RDY) == 0U)
       {
         if ((HAL_GetTick() - tickstart) > PLL2_TIMEOUT_VALUE)
         {
@@ -2499,7 +2500,7 @@ HAL_StatusTypeDef HAL_RCCEx_DisablePLL2(void)
   tickstart = HAL_GetTick();
 
   /* Wait till PLL2 is ready */
-  while (READ_BIT(RCC->CR, RCC_CR_PLL2RDY) != 0U)
+  while (MV_READ_BIT(RCC->CR, RCC_CR_PLL2RDY) != 0U)
   {
     if ((HAL_GetTick() - tickstart) > PLL2_TIMEOUT_VALUE)
     {
@@ -2509,7 +2510,7 @@ HAL_StatusTypeDef HAL_RCCEx_DisablePLL2(void)
   }
 
   /* To save power disable the PLL2 Source, FRACN and Clock outputs */
-  CLEAR_BIT(RCC->PLL2CFGR, RCC_PLL2CFGR_PLL2PEN | RCC_PLL2CFGR_PLL2QEN | RCC_PLL2CFGR_PLL2REN | RCC_PLL2CFGR_PLL2SRC | \
+  MV_CLEAR_BIT(RCC->PLL2CFGR, RCC_PLL2CFGR_PLL2PEN | RCC_PLL2CFGR_PLL2QEN | RCC_PLL2CFGR_PLL2REN | RCC_PLL2CFGR_PLL2SRC | \
             RCC_PLL2CFGR_PLL2FRACEN);
 
   return status;
@@ -2540,7 +2541,7 @@ HAL_StatusTypeDef HAL_RCCEx_EnablePLL3(RCC_PLL3InitTypeDef  *PLL3Init)
   tickstart = HAL_GetTick();
 
   /* Wait till PLL3 is ready to be updated */
-  while (READ_BIT(RCC->CR, RCC_CR_PLL3RDY) != 0U)
+  while (MV_READ_BIT(RCC->CR, RCC_CR_PLL3RDY) != 0U)
   {
     if ((HAL_GetTick() - tickstart) > PLL3_TIMEOUT_VALUE)
     {
@@ -2583,7 +2584,7 @@ HAL_StatusTypeDef HAL_RCCEx_EnablePLL3(RCC_PLL3InitTypeDef  *PLL3Init)
       tickstart = HAL_GetTick();
 
       /* Wait till PLL3 is ready */
-      while (READ_BIT(RCC->CR, RCC_CR_PLL3RDY) == 0U)
+      while (MV_READ_BIT(RCC->CR, RCC_CR_PLL3RDY) == 0U)
       {
         if ((HAL_GetTick() - tickstart) > PLL3_TIMEOUT_VALUE)
         {
@@ -2612,7 +2613,7 @@ HAL_StatusTypeDef HAL_RCCEx_DisablePLL3(void)
   tickstart = HAL_GetTick();
 
   /* Wait till PLL3 is ready */
-  while (READ_BIT(RCC->CR, RCC_CR_PLL3RDY) != 0U)
+  while (MV_READ_BIT(RCC->CR, RCC_CR_PLL3RDY) != 0U)
   {
     if ((HAL_GetTick() - tickstart) > PLL3_TIMEOUT_VALUE)
     {
@@ -2622,7 +2623,7 @@ HAL_StatusTypeDef HAL_RCCEx_DisablePLL3(void)
   }
 
   /* To save power disable the PLL3 Source and Clock outputs */
-  CLEAR_BIT(RCC->PLL3CFGR, RCC_PLL3CFGR_PLL3PEN | RCC_PLL3CFGR_PLL3QEN | RCC_PLL3CFGR_PLL3REN | RCC_PLL3CFGR_PLL3SRC | \
+  MV_CLEAR_BIT(RCC->PLL3CFGR, RCC_PLL3CFGR_PLL3PEN | RCC_PLL3CFGR_PLL3QEN | RCC_PLL3CFGR_PLL3REN | RCC_PLL3CFGR_PLL3SRC | \
             RCC_PLL3CFGR_PLL3FRACEN);
 
   return status;
@@ -2644,16 +2645,16 @@ HAL_StatusTypeDef HAL_RCCEx_EnableMSIPLLModeSelection(uint32_t MSIPLLModeSelecti
   HAL_StatusTypeDef status = HAL_ERROR;
 
   assert_param(IS_RCC_MSIPLLMODE_SELECT(MSIPLLModeSelection));
-  if (READ_BIT(RCC->CR, RCC_CR_MSIPLLEN) == 0U)
+  if (MV_READ_BIT(RCC->CR, RCC_CR_MSIPLLEN) == 0U)
   {
     /* This bit is used only if PLL mode is disabled (MSIPLLEN = 0) */
     if (MSIPLLModeSelection == RCC_MSISPLL_MODE_SEL)
     {
-      SET_BIT(RCC->CR, RCC_CR_MSIPLLSEL);
+      MV_SET_BIT(RCC->CR, RCC_CR_MSIPLLSEL);
     }
     else
     {
-      CLEAR_BIT(RCC->CR, RCC_CR_MSIPLLSEL);
+      MV_CLEAR_BIT(RCC->CR, RCC_CR_MSIPLLSEL);
     }
     status = HAL_OK;
   }
@@ -2672,10 +2673,10 @@ HAL_StatusTypeDef HAL_RCCEx_EnableMSIPLLFastStartup(void)
 {
   HAL_StatusTypeDef status = HAL_ERROR;
 
-  if (READ_BIT(RCC->CR, RCC_CR_MSIPLLEN) == RCC_CR_MSIPLLEN)
+  if (MV_READ_BIT(RCC->CR, RCC_CR_MSIPLLEN) == RCC_CR_MSIPLLEN)
   {
     /* This bit is used only if PLL mode is selected (MSIPLLEN = 1) */
-    SET_BIT(RCC->CR, RCC_CR_MSIPLLFAST);
+    MV_SET_BIT(RCC->CR, RCC_CR_MSIPLLFAST);
     status = HAL_OK;
   }
 
@@ -2691,10 +2692,10 @@ HAL_StatusTypeDef HAL_RCCEx_DisableMSIPLLFastStartup(void)
 {
   HAL_StatusTypeDef status = HAL_ERROR;
 
-  if (READ_BIT(RCC->CR, RCC_CR_MSIPLLEN) == RCC_CR_MSIPLLEN)
+  if (MV_READ_BIT(RCC->CR, RCC_CR_MSIPLLEN) == RCC_CR_MSIPLLEN)
   {
     /* This bit is used only if PLL mode is selected (MSIPLLEN = 1) */
-    CLEAR_BIT(RCC->CR, RCC_CR_MSIPLLFAST);
+    MV_CLEAR_BIT(RCC->CR, RCC_CR_MSIPLLFAST);
     status = HAL_OK;
   }
   return status;
@@ -2760,7 +2761,7 @@ void HAL_RCCEx_StandbyMSIRangeConfig(uint32_t MSIRange)
   */
 void HAL_RCCEx_EnableLSECSS(void)
 {
-  SET_BIT(RCC->BDCR, RCC_BDCR_LSECSSON);
+  MV_SET_BIT(RCC->BDCR, RCC_BDCR_LSECSSON);
 }
 
 /**
@@ -2770,7 +2771,7 @@ void HAL_RCCEx_EnableLSECSS(void)
   */
 void HAL_RCCEx_DisableLSECSS(void)
 {
-  CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSECSSON);
+  MV_CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSECSSON);
 }
 
 /**
@@ -2779,7 +2780,7 @@ void HAL_RCCEx_DisableLSECSS(void)
   */
 void HAL_RCCEx_LSECSS_IRQHandler(void)
 {
-  if (READ_BIT(RCC->BDCR, RCC_BDCR_LSECSSD) != 0U)
+  if (MV_READ_BIT(RCC->BDCR, RCC_BDCR_LSECSSD) != 0U)
   {
     /* RCC LSE Clock Security System interrupt user callback */
     HAL_RCCEx_LSECSS_Callback();
@@ -2836,7 +2837,7 @@ void HAL_RCCEx_EnableLSCO(uint32_t LSCOSource)
     backupchanged = SET;
   }
 
-  MODIFY_REG(RCC->BDCR, RCC_BDCR_LSCOSEL | RCC_BDCR_LSCOEN, LSCOSource | RCC_BDCR_LSCOEN);
+  MV_MODIFY_REG(RCC->BDCR, RCC_BDCR_LSCOSEL | RCC_BDCR_LSCOEN, LSCOSource | RCC_BDCR_LSCOEN);
 
   if (backupchanged == SET)
   {
@@ -2870,7 +2871,7 @@ void HAL_RCCEx_DisableLSCO(void)
     backupchanged = SET;
   }
 
-  CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSCOEN);
+  MV_CLEAR_BIT(RCC->BDCR, RCC_BDCR_LSCOEN);
 
   /* Restore previous configuration */
   if (backupchanged == SET)
@@ -2892,7 +2893,7 @@ void HAL_RCCEx_DisableLSCO(void)
   */
 void HAL_RCCEx_EnableMSIPLLMode(void)
 {
-  SET_BIT(RCC->CR, RCC_CR_MSIPLLEN);
+  MV_SET_BIT(RCC->CR, RCC_CR_MSIPLLEN);
 }
 
 /**
@@ -2902,7 +2903,7 @@ void HAL_RCCEx_EnableMSIPLLMode(void)
   */
 void HAL_RCCEx_DisableMSIPLLMode(void)
 {
-  CLEAR_BIT(RCC->CR, RCC_CR_MSIPLLEN);
+  MV_CLEAR_BIT(RCC->CR, RCC_CR_MSIPLLEN);
 }
 
 /**
@@ -3006,16 +3007,16 @@ void HAL_RCCEx_CRSConfig(const RCC_CRSInitTypeDef *const pInit)
   value |= pInit->ReloadValue;
   /* Set the FELIM[7:0] bits according to ErrorLimitValue value */
   value |= (pInit->ErrorLimitValue << CRS_CFGR_FELIM_Pos);
-  WRITE_REG(CRS->CFGR, value);
+  MV_WRITE_REG(CRS->CFGR, value);
 
   /* Adjust HSI48 oscillator smooth trimming */
   /* Set the TRIM[5:0] bits according to RCC_CRS_HSI48CalibrationValue value */
-  MODIFY_REG(CRS->CR, CRS_CR_TRIM, (pInit->HSI48CalibrationValue << CRS_CR_TRIM_Pos));
+  MV_MODIFY_REG(CRS->CR, CRS_CR_TRIM, (pInit->HSI48CalibrationValue << CRS_CR_TRIM_Pos));
 
   /* START AUTOMATIC SYNCHRONIZATION*/
 
   /* Enable Automatic trimming & Frequency error counter */
-  SET_BIT(CRS->CR, CRS_CR_AUTOTRIMEN | CRS_CR_CEN);
+  MV_SET_BIT(CRS->CR, CRS_CR_AUTOTRIMEN | CRS_CR_CEN);
 }
 
 /**
@@ -3024,7 +3025,7 @@ void HAL_RCCEx_CRSConfig(const RCC_CRSInitTypeDef *const pInit)
   */
 void HAL_RCCEx_CRSSoftwareSynchronizationGenerate(void)
 {
-  SET_BIT(CRS->CR, CRS_CR_SWSYNC);
+  MV_SET_BIT(CRS->CR, CRS_CR_SWSYNC);
 }
 
 /**
@@ -3038,16 +3039,16 @@ void HAL_RCCEx_CRSGetSynchronizationInfo(RCC_CRSSynchroInfoTypeDef *pSynchroInfo
   assert_param(pSynchroInfo != (void *) NULL);
 
   /* Get the reload value */
-  pSynchroInfo->ReloadValue = (uint32_t)(READ_BIT(CRS->CFGR, CRS_CFGR_RELOAD));
+  pSynchroInfo->ReloadValue = (uint32_t)(MV_READ_BIT(CRS->CFGR, CRS_CFGR_RELOAD));
 
   /* Get HSI48 oscillator smooth trimming */
-  pSynchroInfo->HSI48CalibrationValue = (uint32_t)(READ_BIT(CRS->CR, CRS_CR_TRIM) >> CRS_CR_TRIM_Pos);
+  pSynchroInfo->HSI48CalibrationValue = (uint32_t)(MV_READ_BIT(CRS->CR, CRS_CR_TRIM) >> CRS_CR_TRIM_Pos);
 
   /* Get Frequency error capture */
-  pSynchroInfo->FreqErrorCapture = (uint32_t)(READ_BIT(CRS->ISR, CRS_ISR_FECAP) >> CRS_ISR_FECAP_Pos);
+  pSynchroInfo->FreqErrorCapture = (uint32_t)(MV_READ_BIT(CRS->ISR, CRS_ISR_FECAP) >> CRS_ISR_FECAP_Pos);
 
   /* Get Frequency error direction */
-  pSynchroInfo->FreqErrorDirection = (uint32_t)(READ_BIT(CRS->ISR, CRS_ISR_FEDIR));
+  pSynchroInfo->FreqErrorDirection = (uint32_t)(MV_READ_BIT(CRS->ISR, CRS_ISR_FEDIR));
 }
 
 /**
@@ -3152,14 +3153,14 @@ void HAL_RCCEx_CRS_IRQHandler(void)
 {
   uint32_t crserror = RCC_CRS_NONE;
   /* Get current IT flags and IT sources values */
-  uint32_t itflags = READ_REG(CRS->ISR);
-  uint32_t itsources = READ_REG(CRS->CR);
+  uint32_t itflags = MV_READ_REG(CRS->ISR);
+  uint32_t itsources = MV_READ_REG(CRS->CR);
 
   /* Check CRS SYNCOK flag  */
   if (((itflags & RCC_CRS_FLAG_SYNCOK) != 0U) && ((itsources & RCC_CRS_IT_SYNCOK) != 0U))
   {
     /* Clear CRS SYNC event OK flag */
-    WRITE_REG(CRS->ICR, CRS_ICR_SYNCOKC);
+    MV_WRITE_REG(CRS->ICR, CRS_ICR_SYNCOKC);
 
     /* user callback */
     HAL_RCCEx_CRS_SyncOkCallback();
@@ -3168,7 +3169,7 @@ void HAL_RCCEx_CRS_IRQHandler(void)
   else if (((itflags & RCC_CRS_FLAG_SYNCWARN) != 0U) && ((itsources & RCC_CRS_IT_SYNCWARN) != 0U))
   {
     /* Clear CRS SYNCWARN flag */
-    WRITE_REG(CRS->ICR, CRS_ICR_SYNCWARNC);
+    MV_WRITE_REG(CRS->ICR, CRS_ICR_SYNCWARNC);
 
     /* user callback */
     HAL_RCCEx_CRS_SyncWarnCallback();
@@ -3177,7 +3178,7 @@ void HAL_RCCEx_CRS_IRQHandler(void)
   else if (((itflags & RCC_CRS_FLAG_ESYNC) != 0U) && ((itsources & RCC_CRS_IT_ESYNC) != 0U))
   {
     /* frequency error counter reached a zero value */
-    WRITE_REG(CRS->ICR, CRS_ICR_ESYNCC);
+    MV_WRITE_REG(CRS->ICR, CRS_ICR_ESYNCC);
 
     /* user callback */
     HAL_RCCEx_CRS_ExpectedSyncCallback();
@@ -3201,7 +3202,7 @@ void HAL_RCCEx_CRS_IRQHandler(void)
       }
 
       /* Clear CRS Error flags */
-      WRITE_REG(CRS->ICR, CRS_ICR_ERRC);
+      MV_WRITE_REG(CRS->ICR, CRS_ICR_ERRC);
 
       /* user error callback */
       HAL_RCCEx_CRS_ErrorCallback(crserror);
@@ -3293,7 +3294,7 @@ static HAL_StatusTypeDef RCCEx_PLLSource_Enable(uint32_t PllSource)
   {
     case RCC_PLLSOURCE_MSI:
       /* Check whether MSI in not ready and enable it */
-      if (READ_BIT(RCC->CR, RCC_CR_MSISRDY) == 0U)
+      if (MV_READ_BIT(RCC->CR, RCC_CR_MSISRDY) == 0U)
       {
         /* Enable the Internal Multi Speed oscillator (MSI). */
         __HAL_RCC_MSI_ENABLE();
@@ -3302,7 +3303,7 @@ static HAL_StatusTypeDef RCCEx_PLLSource_Enable(uint32_t PllSource)
         tickstart = HAL_GetTick();
 
         /* Wait till MSI is ready */
-        while (READ_BIT(RCC->CR, RCC_CR_MSISRDY) == 0U)
+        while (MV_READ_BIT(RCC->CR, RCC_CR_MSISRDY) == 0U)
         {
           if ((HAL_GetTick() - tickstart) > MSI_TIMEOUT_VALUE)
           {
@@ -3315,7 +3316,7 @@ static HAL_StatusTypeDef RCCEx_PLLSource_Enable(uint32_t PllSource)
 
     case RCC_PLLSOURCE_HSI:
       /* Check whether HSI in not ready and enable it */
-      if (READ_BIT(RCC->CR, RCC_CR_HSIRDY) == 0U)
+      if (MV_READ_BIT(RCC->CR, RCC_CR_HSIRDY) == 0U)
       {
         /* Enable the Internal High Speed oscillator (HSI) */
         __HAL_RCC_HSI_ENABLE();
@@ -3324,7 +3325,7 @@ static HAL_StatusTypeDef RCCEx_PLLSource_Enable(uint32_t PllSource)
         tickstart = HAL_GetTick();
 
         /* Wait till MSI is ready */
-        while (READ_BIT(RCC->CR, RCC_CR_HSIRDY) == 0U)
+        while (MV_READ_BIT(RCC->CR, RCC_CR_HSIRDY) == 0U)
         {
           if ((HAL_GetTick() - tickstart) > HSI_TIMEOUT_VALUE)
           {
@@ -3337,16 +3338,16 @@ static HAL_StatusTypeDef RCCEx_PLLSource_Enable(uint32_t PllSource)
 
     case RCC_PLLSOURCE_HSE:
       /* Check whether HSE in not ready and enable it */
-      if (READ_BIT(RCC->CR, RCC_CR_HSERDY) == 0U)
+      if (MV_READ_BIT(RCC->CR, RCC_CR_HSERDY) == 0U)
       {
         /* Enable the External High Speed oscillator (HSE) */
-        SET_BIT(RCC->CR, RCC_CR_HSEON);
+        MV_SET_BIT(RCC->CR, RCC_CR_HSEON);
 
         /* Get Start Tick*/
         tickstart = HAL_GetTick();
 
         /* Wait till HSE is ready */
-        while (READ_BIT(RCC->CR, RCC_CR_HSERDY) == 0U)
+        while (MV_READ_BIT(RCC->CR, RCC_CR_HSERDY) == 0U)
         {
           if ((HAL_GetTick() - tickstart) > HSE_TIMEOUT_VALUE)
           {


### PR DESCRIPTION
Calls to any of the following functions accessing RCC:
SET_BIT, CLEAR_BIT, READ_BIT, CLEAR_REG, WRITE_REG, READ_REG, MODIFY_REG

Should be changed to call the appropriate microvisor specific function for
mediated peripheral access:
MV_SET_BIT, MV_CLEAR_BIT, MV_READ_BIT, MV_CLEAR_REG, MV_WRITE_REG,
MV_READ_REG, MV_MODIFY_REG
