### PR TITLE
Remove all code that writes FLASH->ACR

### DIFF
--- a/Drivers/STM32U5xx_HAL_Driver/Inc/stm32u5xx_hal_flash.h
+++ b/Drivers/STM32U5xx_HAL_Driver/Inc/stm32u5xx_hal_flash.h
@@ -26,6 +26,7 @@ extern "C" {
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32u5xx_hal_def.h"
+#include "mv_bitops.h"
 
 /** @addtogroup STM32U5xx_HAL_Driver
   * @{
@@ -665,8 +666,9 @@ typedef struct
   *     @arg FLASH_LATENCY_14: FLASH Fourteen wait states
   *     @arg FLASH_LATENCY_15: FLASH Fifteen wait states
   * @retval None
+  * @warning Not supported on microvisor.  This macro does nothing.
   */
-#define __HAL_FLASH_SET_LATENCY(__LATENCY__)    MODIFY_REG(FLASH->ACR, FLASH_ACR_LATENCY, (__LATENCY__))
+#define __HAL_FLASH_SET_LATENCY(__LATENCY__)    do {} while (0)
 
 /**
   * @brief  Get the FLASH Latency.
@@ -689,31 +691,35 @@ typedef struct
   *     @arg FLASH_LATENCY_14: FLASH Fourteen wait states
   *     @arg FLASH_LATENCY_15: FLASH Fifteen wait states
   */
-#define __HAL_FLASH_GET_LATENCY()               READ_BIT(FLASH->ACR, FLASH_ACR_LATENCY)
+#define __HAL_FLASH_GET_LATENCY()               MV_READ_BIT(FLASH->ACR, FLASH_ACR_LATENCY)
 
 /**
   * @brief  Enable the FLASH prefetch buffer.
   * @retval None
+  * @warning Not supported on microvisor.  This macro does nothing.
   */
-#define __HAL_FLASH_PREFETCH_BUFFER_ENABLE()    SET_BIT(FLASH->ACR, FLASH_ACR_PRFTEN)
+#define __HAL_FLASH_PREFETCH_BUFFER_ENABLE()    do {} while (0)
 
 /**
   * @brief  Disable the FLASH prefetch buffer.
   * @retval None
+  * @warning Not supported on microvisor.  This macro does nothing.
   */
-#define __HAL_FLASH_PREFETCH_BUFFER_DISABLE()   CLEAR_BIT(FLASH->ACR, FLASH_ACR_PRFTEN)
+#define __HAL_FLASH_PREFETCH_BUFFER_DISABLE()   do {} while (0)
 
 /**
   * @brief  Enable the FLASH power down during Low-Power sleep mode
   * @retval none
+  * @warning Not supported on microvisor.  This macro does nothing.
   */
-#define __HAL_FLASH_SLEEP_POWERDOWN_ENABLE()    SET_BIT(FLASH->ACR, FLASH_ACR_SLEEP_PD)
+#define __HAL_FLASH_SLEEP_POWERDOWN_ENABLE()    do {} while (0)
 
 /**
   * @brief  Disable the FLASH power down during Low-Power sleep mode
   * @retval none
+  * @warning Not supported on microvisor.  This macro does nothing.
   */
-#define __HAL_FLASH_SLEEP_POWERDOWN_DISABLE()   CLEAR_BIT(FLASH->ACR, FLASH_ACR_SLEEP_PD)
+#define __HAL_FLASH_SLEEP_POWERDOWN_DISABLE()   do {} while (0)
 
 /**
   * @}

--- a/Drivers/STM32U5xx_HAL_Driver/Inc/stm32u5xx_ll_system.h
+++ b/Drivers/STM32U5xx_HAL_Driver/Inc/stm32u5xx_ll_system.h
@@ -39,6 +39,7 @@ extern "C" {
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32u5xx.h"
+#include "mv_bitops.h"
 
 /** @addtogroup STM32U5xx_LL_Driver
   * @{
@@ -1292,10 +1293,10 @@ __STATIC_INLINE void LL_VREFBUF_SetTrimming(uint32_t Value)
   *         @arg @ref LL_FLASH_LATENCY_14
   *         @arg @ref LL_FLASH_LATENCY_15
   * @retval None
+  * @warning Not supported on Microvisor.  This function does nothing.
   */
 __STATIC_INLINE void LL_FLASH_SetLatency(uint32_t Latency)
 {
-  MODIFY_REG(FLASH->ACR, FLASH_ACR_LATENCY, Latency);
 }
 
 /**
@@ -1321,7 +1322,7 @@ __STATIC_INLINE void LL_FLASH_SetLatency(uint32_t Latency)
   */
 __STATIC_INLINE uint32_t LL_FLASH_GetLatency(void)
 {
-  return (uint32_t)(READ_BIT(FLASH->ACR, FLASH_ACR_LATENCY));
+  return (uint32_t)(MV_READ_BIT(FLASH->ACR, FLASH_ACR_LATENCY));
 }
 
 /**
@@ -1337,18 +1338,10 @@ __STATIC_INLINE uint32_t LL_FLASH_GetLatency(void)
   *         FLASH_PDKEYR PDKEY2_1      LL_FLASH_EnableRunPowerDown\n
   *         FLASH_PDKEYR PDKEY2_2      LL_FLASH_EnableRunPowerDown
   * @retval None
+  * @warning Not supported on Microvisor.  This function does nothing.
   */
 __STATIC_INLINE void LL_FLASH_EnableRunPowerDown(void)
 {
-  /* Following values must be written consecutively to unlock the RUN_PD bit in
-  FLASH_ACR */
-  WRITE_REG(FLASH->PDKEY1R, LL_FLASH_PDKEY1_1);
-  WRITE_REG(FLASH->PDKEY1R, LL_FLASH_PDKEY1_2);
-  WRITE_REG(FLASH->PDKEY2R, LL_FLASH_PDKEY2_1);
-  WRITE_REG(FLASH->PDKEY2R, LL_FLASH_PDKEY2_2);
-
-  /*Request to enter flash in power mode */
-  SET_BIT(FLASH->ACR, FLASH_ACR_PDREQ1 | FLASH_ACR_PDREQ2);
 }
 
 /**
@@ -1362,16 +1355,10 @@ __STATIC_INLINE void LL_FLASH_EnableRunPowerDown(void)
   *         FLASH_PDKEYR PDKEY1_1      LL_FLASH_EnableRunPowerDown\n
   *         FLASH_PDKEYR PDKEY1_2      LL_FLASH_EnableRunPowerDown\n
   * @retval None
+  * @warning Not supported on Microvisor.  This function does nothing.
   */
 __STATIC_INLINE void LL_FLASH_EnableRunPowerDownBank1(void)
 {
-  /* Following values must be written consecutively to unlock the RUN_PD bit in
-  FLASH_ACR */
-  WRITE_REG(FLASH->PDKEY1R, LL_FLASH_PDKEY1_1);
-  WRITE_REG(FLASH->PDKEY1R, LL_FLASH_PDKEY1_2);
-
-  /*Request to enter flash in power mode */
-  SET_BIT(FLASH->ACR, FLASH_ACR_PDREQ1);
 }
 
 /**
@@ -1385,16 +1372,10 @@ __STATIC_INLINE void LL_FLASH_EnableRunPowerDownBank1(void)
   *         FLASH_PDKEYR PDKEY2_1      LL_FLASH_EnableRunPowerDown\n
   *         FLASH_PDKEYR PDKEY2_2      LL_FLASH_EnableRunPowerDown\n
   * @retval None
+  * @warning Not supported on Microvisor.  This function does nothing.
   */
 __STATIC_INLINE void LL_FLASH_EnableRunPowerDownBank2(void)
 {
-  /* Following values must be written consecutively to unlock the RUN_PD bit in
-  FLASH_ACR */
-  WRITE_REG(FLASH->PDKEY2R, LL_FLASH_PDKEY2_1);
-  WRITE_REG(FLASH->PDKEY2R, LL_FLASH_PDKEY2_2);
-
-  /*Request to enter flash in power mode */
-  SET_BIT(FLASH->ACR, FLASH_ACR_PDREQ2);
 }
 
 /**
@@ -1403,20 +1384,20 @@ __STATIC_INLINE void LL_FLASH_EnableRunPowerDownBank2(void)
   *       is on-going
   * @rmtoll FLASH_ACR    SLEEP_PD      LL_FLASH_EnableSleepPowerDown
   * @retval None
+  * @warning Not supported on Microvisor.  This function does nothing.
   */
 __STATIC_INLINE void LL_FLASH_EnableSleepPowerDown(void)
 {
-  SET_BIT(FLASH->ACR, FLASH_ACR_SLEEP_PD);
 }
 
 /**
   * @brief  Disable Flash Power-down mode during Sleep or Low-power sleep mode
   * @rmtoll FLASH_ACR    SLEEP_PD      LL_FLASH_DisableSleepPowerDown
   * @retval None
+  * @warning Not supported on Microvisor.  This function does nothing.
   */
 __STATIC_INLINE void LL_FLASH_DisableSleepPowerDown(void)
 {
-  CLEAR_BIT(FLASH->ACR, FLASH_ACR_SLEEP_PD);
 }
 /**
   * @}

--- a/Drivers/STM32U5xx_HAL_Driver/Src/stm32u5xx_hal_flash_ex.c
+++ b/Drivers/STM32U5xx_HAL_Driver/Src/stm32u5xx_hal_flash_ex.c
@@ -719,84 +719,11 @@ uint32_t HAL_FLASHEx_GetSecInversion(void)
   *            @arg FLASH_BANK_2: Flash Bank 2
   *            @arg FLASH_BANK_BOTH: Flash Bank 1 and Bank 2
   * @retval HAL Status
+  * @warning Not supported on Microvisor.  Returns HAL_ERROR
   */
 HAL_StatusTypeDef HAL_FLASHEx_EnablePowerDown(uint32_t Banks)
 {
-  HAL_StatusTypeDef status = HAL_OK;
-  uint32_t tickstart;
-
-  /* Check the parameters */
-  assert_param(IS_FLASH_BANK(Banks));
-
-  /* Request power-down mode for Bank 1 */
-  if ((Banks & FLASH_BANK_1) != 0U)
-  {
-    /* Check PD1 and PDREQ1 bits (Bank 1 is not in power-down mode and not being
-       already under power-down request) */
-    if ((FLASH->NSSR & FLASH_NSSR_PD1) != 0U)
-    {
-      status = HAL_ERROR;
-    }
-    else if ((FLASH->ACR & FLASH_ACR_PDREQ1) != 0U)
-    {
-      status = HAL_ERROR;
-    }
-    else
-    {
-      /* Unlock PDREQ1 bit */
-      WRITE_REG(FLASH->PDKEY1R, FLASH_PDKEY1_1);
-      WRITE_REG(FLASH->PDKEY1R, FLASH_PDKEY1_2);
-
-      /* Set PDREQ1 in FLASH_ACR register */
-      SET_BIT(FLASH->ACR, FLASH_ACR_PDREQ1);
-
-      /* Check PD1 bit */
-      tickstart = HAL_GetTick();
-      while (((FLASH->NSSR & FLASH_NSSR_PD1) != FLASH_NSSR_PD1))
-      {
-        if ((HAL_GetTick() - tickstart) > FLASH_TIMEOUT_VALUE)
-        {
-          return HAL_TIMEOUT;
-        }
-      }
-    }
-  }
-
-  /* Request power-down mode for Bank 2 */
-  if ((Banks & FLASH_BANK_2) != 0U)
-  {
-    /* Check PD2 and PDREQ2 bits (Bank 2 is not in power-down mode and not being
-       already under power-down request) */
-    if ((FLASH->NSSR & FLASH_NSSR_PD2) != 0U)
-    {
-      status = HAL_ERROR;
-    }
-    else if ((FLASH->ACR & FLASH_ACR_PDREQ2) != 0U)
-    {
-      status = HAL_ERROR;
-    }
-    else
-    {
-      /* Unlock PDREQ2 bit */
-      WRITE_REG(FLASH->PDKEY2R, FLASH_PDKEY2_1);
-      WRITE_REG(FLASH->PDKEY2R, FLASH_PDKEY2_2);
-
-      /* Set PDREQ2 in FLASH_ACR register */
-      SET_BIT(FLASH->ACR, FLASH_ACR_PDREQ2);
-
-      /* Check PD2 bit */
-      tickstart = HAL_GetTick();
-      while (((FLASH->NSSR & FLASH_NSSR_PD2) != FLASH_NSSR_PD2))
-      {
-        if ((HAL_GetTick() - tickstart) > FLASH_TIMEOUT_VALUE)
-        {
-          return HAL_TIMEOUT;
-        }
-      }
-    }
-  }
-
-  return status;
+  return HAL_ERROR;
 }
 
 /**
@@ -808,24 +735,11 @@ HAL_StatusTypeDef HAL_FLASHEx_EnablePowerDown(uint32_t Banks)
   *           @arg FLASH_LPM_DISABLE: Flash is in normal read mode
   *
   * @retval HAL Status
+  * @warning Not supported on Microvisor.  Returns HAL_ERROR
   */
 HAL_StatusTypeDef HAL_FLASHEx_ConfigLowPowerRead(uint32_t ConfigLPM)
 {
-  HAL_StatusTypeDef status = HAL_OK;
-
-  /* Check the parameters */
-  assert_param(IS_FLASH_CFGLPM(ConfigLPM));
-
-  /* Set LPM Bit in FLASH_ACR register */
-  MODIFY_REG(FLASH->ACR, FLASH_ACR_LPM, ConfigLPM);
-
-  /* Check that low power read mode has been activated */
-  if (READ_BIT(FLASH->ACR, FLASH_ACR_LPM) != ConfigLPM)
-  {
-    status = HAL_ERROR;
-  }
-
-  return status;
+  return HAL_ERROR;
 }
 
 /**
@@ -838,7 +752,7 @@ HAL_StatusTypeDef HAL_FLASHEx_ConfigLowPowerRead(uint32_t ConfigLPM)
   */
 uint32_t HAL_FLASHEx_GetLowPowerRead(void)
 {
-  return (FLASH->ACR & FLASH_ACR_LPM);
+  return MV_READ_BIT(FLASH->ACR, FLASH_ACR_LPM);
 }
 
 /**


### PR DESCRIPTION
This is no longer allowed on Microvisor, as it breaks separation
between secure and non-secure modes.  Namely, non-secure can
power down secure flash, or glitch reads by setting the latency
incorrectly.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
